### PR TITLE
[Windows] Decouple the launcher from the calling prompt

### DIFF
--- a/windows/launch-lem.bat
+++ b/windows/launch-lem.bat
@@ -1,0 +1,7 @@
+@echo off
+
+set PATH=%~dp0lib;%PATH%
+cd %~dp0
+
+start "" "lem-internal.exe"
+exit

--- a/windows/lem.bat
+++ b/windows/lem.bat
@@ -1,7 +1,3 @@
 @echo off
 
-set PATH=%~dp0lib;%PATH%
-cd %~dp0
-
-start "" "lem-internal.exe"
-exit
+start %~dp0/launch-lem.bat

--- a/windows/lem.bat
+++ b/windows/lem.bat
@@ -1,6 +1,7 @@
 @echo off
 
 set PATH=%~dp0lib;%PATH%
+cd %~dp0
 
 start "" "lem-internal.exe"
 exit


### PR DESCRIPTION
This pull request contains two commits. The first is
to allow the launcher to run from anywhere. The
next is to stop the launcher from modifying the
calling command prompt.